### PR TITLE
feat(secret scanning): support `pull_request_comment_url`

### DIFF
--- a/github/github-accessors.go
+++ b/github/github-accessors.go
@@ -22958,6 +22958,14 @@ func (s *SecretScanningAlertLocationDetails) GetPath() string {
 	return *s.Path
 }
 
+// GetPullRequestCommentURL returns the PullRequestCommentURL field if it's non-nil, zero value otherwise.
+func (s *SecretScanningAlertLocationDetails) GetPullRequestCommentURL() string {
+	if s == nil || s.PullRequestCommentURL == nil {
+		return ""
+	}
+	return *s.PullRequestCommentURL
+}
+
 // GetStartColumn returns the StartColumn field if it's non-nil, zero value otherwise.
 func (s *SecretScanningAlertLocationDetails) GetStartColumn() int {
 	if s == nil || s.StartColumn == nil {

--- a/github/github-accessors_test.go
+++ b/github/github-accessors_test.go
@@ -29433,6 +29433,17 @@ func TestSecretScanningAlertLocationDetails_GetPath(tt *testing.T) {
 	s.GetPath()
 }
 
+func TestSecretScanningAlertLocationDetails_GetPullRequestCommentURL(tt *testing.T) {
+	tt.Parallel()
+	var zeroValue string
+	s := &SecretScanningAlertLocationDetails{PullRequestCommentURL: &zeroValue}
+	s.GetPullRequestCommentURL()
+	s = &SecretScanningAlertLocationDetails{}
+	s.GetPullRequestCommentURL()
+	s = nil
+	s.GetPullRequestCommentURL()
+}
+
 func TestSecretScanningAlertLocationDetails_GetStartColumn(tt *testing.T) {
 	tt.Parallel()
 	var zeroValue int

--- a/github/secret_scanning.go
+++ b/github/secret_scanning.go
@@ -44,15 +44,16 @@ type SecretScanningAlertLocation struct {
 
 // SecretScanningAlertLocationDetails represents the location details for a secret scanning alert.
 type SecretScanningAlertLocationDetails struct {
-	Path        *string `json:"path,omitempty"`
-	Startline   *int    `json:"start_line,omitempty"`
-	EndLine     *int    `json:"end_line,omitempty"`
-	StartColumn *int    `json:"start_column,omitempty"`
-	EndColumn   *int    `json:"end_column,omitempty"`
-	BlobSHA     *string `json:"blob_sha,omitempty"`
-	BlobURL     *string `json:"blob_url,omitempty"`
-	CommitSHA   *string `json:"commit_sha,omitempty"`
-	CommitURL   *string `json:"commit_url,omitempty"`
+	Path                  *string `json:"path,omitempty"`
+	Startline             *int    `json:"start_line,omitempty"`
+	EndLine               *int    `json:"end_line,omitempty"`
+	StartColumn           *int    `json:"start_column,omitempty"`
+	EndColumn             *int    `json:"end_column,omitempty"`
+	BlobSHA               *string `json:"blob_sha,omitempty"`
+	BlobURL               *string `json:"blob_url,omitempty"`
+	CommitSHA             *string `json:"commit_sha,omitempty"`
+	CommitURL             *string `json:"commit_url,omitempty"`
+	PullRequestCommentURL *string `json:"pull_request_comment_url,omitempty"`
 }
 
 // SecretScanningAlertListOptions specifies optional parameters to the SecretScanningService.ListAlertsForEnterprise method.


### PR DESCRIPTION
Modify `SecretScanningAlertLocationDetails` to recognize API responses of type `pull_request_comment_url`.