### PR TITLE
fix: manually update module name

### DIFF
--- a/example/actionpermissions/main.go
+++ b/example/actionpermissions/main.go
@@ -14,7 +14,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v66/github"
+	"github.com/parchment-io/go-github/v66/github"
 )
 
 var (

--- a/example/appengine/app.go
+++ b/example/appengine/app.go
@@ -12,7 +12,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/google/go-github/v66/github"
+	"github.com/parchment-io/go-github/v66/github"
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/log"
 )

--- a/example/basicauth/main.go
+++ b/example/basicauth/main.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/google/go-github/v66/github"
+	"github.com/parchment-io/go-github/v66/github"
 	"golang.org/x/term"
 )
 

--- a/example/codespaces/newreposecretwithxcrypto/main.go
+++ b/example/codespaces/newreposecretwithxcrypto/main.go
@@ -37,7 +37,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v66/github"
+	"github.com/parchment-io/go-github/v66/github"
 	"golang.org/x/crypto/nacl/box"
 )
 

--- a/example/codespaces/newusersecretwithxcrypto/main.go
+++ b/example/codespaces/newusersecretwithxcrypto/main.go
@@ -38,7 +38,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v66/github"
+	"github.com/parchment-io/go-github/v66/github"
 	"golang.org/x/crypto/nacl/box"
 )
 

--- a/example/commitpr/main.go
+++ b/example/commitpr/main.go
@@ -33,7 +33,7 @@ import (
 	"time"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
-	"github.com/google/go-github/v66/github"
+	"github.com/parchment-io/go-github/v66/github"
 )
 
 var (

--- a/example/listenvironments/main.go
+++ b/example/listenvironments/main.go
@@ -18,7 +18,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v66/github"
+	"github.com/parchment-io/go-github/v66/github"
 )
 
 func main() {

--- a/example/migrations/main.go
+++ b/example/migrations/main.go
@@ -12,7 +12,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v66/github"
+	"github.com/parchment-io/go-github/v66/github"
 )
 
 func fetchAllUserMigrations() ([]*github.UserMigration, error) {

--- a/example/newfilewithappauth/main.go
+++ b/example/newfilewithappauth/main.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
-	"github.com/google/go-github/v66/github"
+	"github.com/parchment-io/go-github/v66/github"
 )
 
 func main() {

--- a/example/newrepo/main.go
+++ b/example/newrepo/main.go
@@ -16,7 +16,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v66/github"
+	"github.com/parchment-io/go-github/v66/github"
 )
 
 var (

--- a/example/newreposecretwithlibsodium/main.go
+++ b/example/newreposecretwithlibsodium/main.go
@@ -36,7 +36,7 @@ import (
 	"os"
 
 	sodium "github.com/GoKillers/libsodium-go/cryptobox"
-	"github.com/google/go-github/v66/github"
+	"github.com/parchment-io/go-github/v66/github"
 )
 
 var (

--- a/example/newreposecretwithxcrypto/main.go
+++ b/example/newreposecretwithxcrypto/main.go
@@ -37,7 +37,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v66/github"
+	"github.com/parchment-io/go-github/v66/github"
 	"golang.org/x/crypto/nacl/box"
 )
 

--- a/example/ratelimit/main.go
+++ b/example/ratelimit/main.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 
 	"github.com/gofri/go-github-ratelimit/github_ratelimit"
-	"github.com/google/go-github/v66/github"
+	"github.com/parchment-io/go-github/v66/github"
 )
 
 func main() {

--- a/example/simple/main.go
+++ b/example/simple/main.go
@@ -12,7 +12,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v66/github"
+	"github.com/parchment-io/go-github/v66/github"
 )
 
 // Fetch all the public organizations' membership of a user.

--- a/example/tokenauth/main.go
+++ b/example/tokenauth/main.go
@@ -15,7 +15,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v66/github"
+	"github.com/parchment-io/go-github/v66/github"
 	"golang.org/x/term"
 )
 

--- a/example/topics/main.go
+++ b/example/topics/main.go
@@ -12,7 +12,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v66/github"
+	"github.com/parchment-io/go-github/v66/github"
 )
 
 // Fetch and lists all the public topics associated with the specified GitHub topic.

--- a/example/verifyartifact/main.go
+++ b/example/verifyartifact/main.go
@@ -18,7 +18,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/go-github/v66/github"
+	"github.com/parchment-io/go-github/v66/github"
 	"github.com/sigstore/sigstore-go/pkg/bundle"
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/verify"

--- a/github/doc.go
+++ b/github/doc.go
@@ -8,7 +8,7 @@ Package github provides a client for using the GitHub API.
 
 Usage:
 
-	import "github.com/google/go-github/v66/github"	// with go modules enabled (GO111MODULE=on or outside GOPATH)
+	import "github.com/parchment-io/go-github/v66/github"	// with go modules enabled (GO111MODULE=on or outside GOPATH)
 	import "github.com/google/go-github/github"     // with go modules disabled
 
 Construct a new GitHub client, then use the various services on the client to

--- a/github/examples_test.go
+++ b/github/examples_test.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/google/go-github/v66/github"
+	"github.com/parchment-io/go-github/v66/github"
 )
 
 func ExampleMarkdownService_Render() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/google/go-github/v66
+module github.com/parchment-io/go-github/v66
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/scrape/apps.go
+++ b/scrape/apps.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
-	"github.com/google/go-github/v66/github"
+	"github.com/parchment-io/go-github/v66/github"
 )
 
 // AppRestrictionsEnabled returns whether the specified organization has

--- a/scrape/apps_test.go
+++ b/scrape/apps_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-github/v66/github"
+	"github.com/parchment-io/go-github/v66/github"
 )
 
 func Test_AppRestrictionsEnabled(t *testing.T) {

--- a/test/fields/fields.go
+++ b/test/fields/fields.go
@@ -25,7 +25,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/google/go-github/v66/github"
+	"github.com/parchment-io/go-github/v66/github"
 )
 
 var (

--- a/test/integration/activity_test.go
+++ b/test/integration/activity_test.go
@@ -11,7 +11,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/go-github/v66/github"
+	"github.com/parchment-io/go-github/v66/github"
 )
 
 const (

--- a/test/integration/authorizations_test.go
+++ b/test/integration/authorizations_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v66/github"
+	"github.com/parchment-io/go-github/v66/github"
 )
 
 const msgEnvMissing = "Skipping test because the required environment variable (%v) is not present."

--- a/test/integration/github_test.go
+++ b/test/integration/github_test.go
@@ -14,7 +14,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/google/go-github/v66/github"
+	"github.com/parchment-io/go-github/v66/github"
 )
 
 var (

--- a/test/integration/repos_test.go
+++ b/test/integration/repos_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-github/v66/github"
+	"github.com/parchment-io/go-github/v66/github"
 )
 
 func TestRepositories_CRUD(t *testing.T) {

--- a/test/integration/users_test.go
+++ b/test/integration/users_test.go
@@ -13,7 +13,7 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/google/go-github/v66/github"
+	"github.com/parchment-io/go-github/v66/github"
 )
 
 func TestUsers_Get(t *testing.T) {

--- a/tools/metadata/main.go
+++ b/tools/metadata/main.go
@@ -16,7 +16,7 @@ import (
 	"path/filepath"
 
 	"github.com/alecthomas/kong"
-	"github.com/google/go-github/v66/github"
+	"github.com/parchment-io/go-github/v66/github"
 )
 
 var helpVars = kong.Vars{

--- a/tools/metadata/main_test.go
+++ b/tools/metadata/main_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-github/v66/github"
+	"github.com/parchment-io/go-github/v66/github"
 )
 
 func TestUpdateGo(t *testing.T) {

--- a/tools/metadata/metadata.go
+++ b/tools/metadata/metadata.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/google/go-github/v66/github"
+	"github.com/parchment-io/go-github/v66/github"
 	"gopkg.in/yaml.v3"
 )
 

--- a/tools/metadata/openapi.go
+++ b/tools/metadata/openapi.go
@@ -14,7 +14,7 @@ import (
 	"strconv"
 
 	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/google/go-github/v66/github"
+	"github.com/parchment-io/go-github/v66/github"
 	"golang.org/x/sync/errgroup"
 )
 


### PR DESCRIPTION
Update module name from `github.com/google/go-github` to `github.com/parchment-io/go-github`. This should resolve downstream problems pertaining to importing this module.